### PR TITLE
Fix: Remove poetry dependency from s2train.py shebang

### DIFF
--- a/src/s2train.py
+++ b/src/s2train.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S poetry run python
+#!/usr/bin/env python3
 """Submits frames to a Groundlight detector for training.
 By default, waits for confident answers, which generally means human review.
 All is done in diversity order, so the frames are spread out.


### PR DESCRIPTION
Changed shebang from 'poetry run python' to 'python3' to allow the script to work with venv without requiring poetry.